### PR TITLE
ability to add optional env vars, labels and annotations

### DIFF
--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "jellyfin.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
     {{- if .Values.enableDLNA }}
       hostNetwork: true

--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         {{- with .Values.extraPodLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .Values.extraPodAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- if .Values.enableDLNA }}
       hostNetwork: true

--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
             {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
+          {{- if .Values.extraContainers }}
+          {{- toYaml .Values.extraContainers | nindent 10 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -122,7 +122,6 @@ extraVolumeMounts: []
   #- mountPath: /dev/dri/renderD129
   #  name: renderD129
 
-# additional labels applied to the pod
 extraPodLabels: {}
 
 extraEnvVars: []
@@ -131,3 +130,5 @@ extraEnvVars: []
 
 # additional annotations applied to the pod
 extraPodAnnotations: {}
+
+extraContainers: {}

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -122,3 +122,5 @@ extraVolumeMounts: []
   #- mountPath: /dev/dri/renderD129
   #  name: renderD129
 
+# additional labels applied to the pod
+extraPodLabels: {}

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -128,3 +128,6 @@ extraPodLabels: {}
 extraEnvVars: []
   #- name: MY_ENV_VAR
   #  value: my-env-var-value
+
+# additional annotations applied to the pod
+extraPodAnnotations: {}


### PR DESCRIPTION
Made these changes before I saw in the docs that Jellyfin already adds `NVIDIA_VISIBLE_DEVICES` and `NVIDIA_DRIVER_CAPABILITIES` vars, but will still be useful for other things.

EDIT:
Ended up also adding extra annotations and labels