### PR TITLE
Missmatch between the README and the values.yaml (Service.type)

### DIFF
--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -19,7 +19,7 @@ fullnameOverride: ""
 enableDLNA: false
 
 service:
-  type: LoadBalancer
+  type: ClusterIP
   port: 8096
   ## Specify the nodePort value for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport


### PR DESCRIPTION
The [README.md](https://github.com/jellyfin/jellyfin-helm/blob/master/charts/jellyfin/README.md) default value for `Service.type` states the following value:

- ClusterIP

In the the [values.yaml](https://github.com/jellyfin/jellyfin-helm/tree/master/charts/jellyfin) file, it uses the following:

- LoadBalancer