### PR TITLE
Documentation improvements and custom volume configuration for config/media persistence

### DIFF
--- a/charts/jellyfin/README.md
+++ b/charts/jellyfin/README.md
@@ -38,11 +38,13 @@ The following tables lists the configurable parameters of the Jellyfin chart and
 | `persistence.config.existingClaim`| Use an existing PVC to persist data | `nil` |
 | `persistence.config.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.config.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.config.customVolume`  | When set and `persistence.config.enabled` is false, will configure a custom volume instead of an `emptyDir` | `nil` |
 | `persistence.media.enabled`      | Use persistent volume to store configuration data | `true` |
 | `persistence.media.size`         | Size of persistent volume claim | `10Gi` |
 | `persistence.media.existingClaim`| Use an existing PVC to persist data | `nil` |
 | `persistence.media.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.media.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.media.customVolume`  | When set and `persistence.media.enabled` is false, will configure a custom volume instead of an `emptyDir` | `nil` |
 | `persistence.extraExistingClaimMounts`  | Optionally add multiple existing claims | `[]` |
 | `resources`                | CPU/Memory resource requests/limits | `{}` |
 | `nodeSelector`             | Node labels for pod assignment | `{}` |

--- a/charts/jellyfin/README.md
+++ b/charts/jellyfin/README.md
@@ -28,6 +28,7 @@ The following tables lists the configurable parameters of the Jellyfin chart and
 | `Service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)      | None
 | `ingress.enabled`              | Enables Ingress | `false` |
 | `ingress.annotations`          | Ingress annotations | `{}` |
+| `ingress.ingressClassName`          | Ingress class name | `nil` |
 | `ingress.labels`               | Custom labels                       | `{}`
 | `ingress.path`                 | Ingress path | `/` |
 | `ingress.hosts`                | Ingress accepted hostnames | `chart-example.local` |

--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -118,6 +118,8 @@ spec:
       {{- if .Values.persistence.config.enabled }}
         persistentVolumeClaim:
           claimName: {{ if .Values.persistence.config.existingClaim }}{{ .Values.persistence.config.existingClaim }}{{- else }}{{ template "jellyfin.fullname" . }}-config{{- end }}
+      {{- else if .Values.persistence.config.customVolume }}
+        {{.Values.persistence.media.customVolume | toYaml | nindent 8 }}
       {{- else }}
         emptyDir: {}
       {{- end }}
@@ -125,6 +127,8 @@ spec:
       {{- if .Values.persistence.media.enabled }}
         persistentVolumeClaim:
           claimName: {{ if .Values.persistence.media.existingClaim }}{{ .Values.persistence.media.existingClaim }}{{- else }}{{ template "jellyfin.fullname" . }}-media{{- end }}
+      {{- else if .Values.persistence.media.customVolume }}
+        {{- .Values.persistence.media.customVolume | toYaml | nindent 8 }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -71,6 +71,18 @@ persistence:
     # subPath: some-subpath
     accessMode: ReadWriteOnce
     size: 1Gi
+    ## If you neither want to create a PVC, nor use a pre-existing one,
+    ## but instead want to use a custom volume, simply set and configure
+    ## the customVolume section with your volume definition.
+    ## This can be useful, for instance, to hook into an NFS endpoint
+    ## by creating an NFS volume.
+    ## persistence.config.enabled takes precedence over the custom volume definition
+    ## so make sure to set it to false if you intend to use a custom volume.
+    # customVolume:
+    #   nfs:
+    #     server: my-nfs-server.example.com
+    #     path: /my-nfs-volume
+    #     readOnly: false
   media:
     enabled: false
     ## Directory where media is persisted
@@ -88,6 +100,18 @@ persistence:
     # subPath: some-subpath
     accessMode: ReadWriteOnce
     size: 10Gi
+    ## If you neither want to create a PVC, nor use a pre-existing one,
+    ## but instead want to use a custom volume, simply set and configure
+    ## the customVolume section with your volume definition.
+    ## This can be useful, for instance, to hook into an NFS endpoint
+    ## by creating an NFS volume.
+    ## persistence.media.enabled takes precedence over the custom volume definition
+    ## so make sure to set it to false if you intend to use a custom volume.
+    # customVolume:
+    #   nfs:
+    #     server: my-nfs-server.example.com
+    #     path: /my-nfs-volume
+    #     readOnly: false
   extraExistingClaimMounts: []
     # - name: external-mount
     #   mountPath: /srv/external-mount

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -44,6 +44,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  # ingressClassName: nginx
   path: /
   hosts:
     - chart-example.local

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -47,11 +47,11 @@ ingress:
   # ingressClassName: nginx
   path: /
   hosts:
-    - chart-example.local
+    - jellyfin.local
   tls: []
-  #  - secretName: chart-example-tls
+  #  - secretName: jellyfin-tls
   #    hosts:
-  #      - chart-example.local
+  #      - jellyfin.local
 
 persistence:
   config:


### PR DESCRIPTION
I wanted my jellyfin deployment to use a volume from an NFS server instead of a local PVC or `emptyDir`. I added the `persistence.media.customVolume` and `persistence.config.customVolume` fields.
Those fields should contain a volume definition (except the name, which is already set to be `config` and `media` respectively by the deployment template) which will be applied if it is set, and if `persistence.[config|media].enabled` is `false`.

With this, users can set a custom volume for the media mount point, such as an NFS volume, for example:
```yaml
...
persistence:
  media:
    enabled: false
    customVolume:
      nfs:
        server: my-nfs-server.example.com
        path: /my-nfs-volume
        readOnly: false
```

Also documented `ingress.ingressClassName` in the `README` and the default `values.yaml` file, and changed the default ingress host names from `example-chart.local` to `jellyfin.local`.