### PR TITLE
fix(ci): :bug: use PAT to push

### DIFF
--- a/.github/workflows/app_release.yaml
+++ b/.github/workflows/app_release.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+         persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -58,7 +60,9 @@ jobs:
         git commit -m "chore(jellyfin): Bump chart version to ${{ steps.bump_version.outputs.new_version }} and set appVersion to ${{ github.event.inputs.jellyfin_version }}"
 
     - name: Push changes
-      run: git push
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create Git tag
       id: create_tag

--- a/.github/workflows/app_release.yaml
+++ b/.github/workflows/app_release.yaml
@@ -66,6 +66,9 @@ jobs:
         new_version="${{ steps.bump_version.outputs.new_version }}"
         git tag "$new_version"
         echo "Tag created: $new_version"
-
-    - name: Push tag
-      run: git push origin "${{ steps.bump_version.outputs.new_version }}"
+        
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.PAT }}
+        tags: true

--- a/.github/workflows/app_release.yaml
+++ b/.github/workflows/app_release.yaml
@@ -74,5 +74,5 @@ jobs:
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ secrets.PAT }}
+        github_token: ${{ secrets.JF_BOT_TOKEN }}
         tags: true

--- a/.github/workflows/app_release.yaml
+++ b/.github/workflows/app_release.yaml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
          persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
 

--- a/.github/workflows/app_release.yaml
+++ b/.github/workflows/app_release.yaml
@@ -50,7 +50,7 @@ jobs:
         sed -i "s/^appVersion:.*/appVersion: $jellyfin_version/" charts/jellyfin/Chart.yaml
 
         # Output the new chart version for further use
-        echo "::set-output name=new_version::$new_version"
+        echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
     - name: Commit changes
       run: |

--- a/.github/workflows/app_release.yaml
+++ b/.github/workflows/app_release.yaml
@@ -62,7 +62,7 @@ jobs:
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.JF_BOT_TOKEN }}
 
     - name: Create Git tag
       id: create_tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Install Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "jellyfin-bot"
+          git config --global user.email "team@jellyfin.org"
 
       - name: Install Helm
         uses: azure/setup-helm@v4


### PR DESCRIPTION
The builtin token used to push to the repository doesn't trigger downstream jobs like the release job. The workaround is to create a PAT on the group and set it as a secret named `PAT` to the repo. 