### PR TITLE
Expose pod and container SecurityContext fields for Jellyfin pod

### DIFF
--- a/charts/jellyfin/README.md.gotmpl
+++ b/charts/jellyfin/README.md.gotmpl
@@ -58,3 +58,30 @@ helm install <release-name> <chart-name> -f values.yaml
 {{ template "chart.valuesSection" . }}
 
 {{ template "helm-docs.versionFooter" . }}
+
+## Hardware acceleration
+
+Out of the box the pod does not have the necessary permissions to enable hardware acceleration (HWA) in Jellyfin.
+Adding the following Helm values should make it enable you to use hardware acceleration features.
+Some settings may need to be tweaked depending on the type of device (Intel/AMD/NVIDIA/...) and your container runtime.
+
+Please refer to the Jellyfin upstream documentation for more information about hardware acceleration: <https://jellyfin.org/docs/general/administration/hardware-acceleration/>
+
+```yaml
+securityContext:
+  capabilities:
+    add:
+      - "SYS_ADMIN"
+    drop:
+      - "ALL"
+  privileged: false
+
+extraVolumes:
+  - name: hwa
+    hostPath:
+      path: /dev/dri
+
+extraVolumeMounts:
+  - name: hwa
+    mountPath: /dev/dri
+```

--- a/charts/jellyfin/templates/config-pvc.yaml
+++ b/charts/jellyfin/templates/config-pvc.yaml
@@ -9,6 +9,13 @@ metadata:
     helm.sh/chart: {{ include "jellyfin.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.persistence.config.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.persistence.config.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.config.accessMode | quote }}

--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -125,6 +125,8 @@ spec:
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          terminationMessagePolicy: FallbackToLogsOnError
+          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
   {{- if .Values.extraInitContainers }}
       initContainers:
       {{- toYaml .Values.extraInitContainers | nindent 10 }}
@@ -164,3 +166,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/jellyfin/templates/media-pvc.yaml
+++ b/charts/jellyfin/templates/media-pvc.yaml
@@ -9,6 +9,13 @@ metadata:
     helm.sh/chart: {{ include "jellyfin.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.persistence.media.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.persistence.media.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.media.accessMode | quote }}

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -62,6 +62,10 @@ persistence:
     # subPath: some-subpath
     accessMode: ReadWriteOnce
     size: 1Gi
+    # -- Custom labels to be added to the PVC
+    labels: {}
+    # -- Custom annotations to be added to the PVC
+    annotations: {}
   media:
     enabled: false
     # -- If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.
@@ -72,6 +76,11 @@ persistence:
     # subPath: some-subpath
     accessMode: ReadWriteOnce
     size: 10Gi
+    # -- Custom labels to be added to the PVC
+    labels: {}
+    # -- Custom annotations to be added to the PVC
+    annotations: {}
+
   # -- Add aditional PVs/PVCs to our container. Check values.yaml to see an example.
   extraExistingClaimMounts: []
     # - name: external-mount

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -127,6 +127,21 @@ extraInitContainers: {}
 # -- additional sidecar containers to run inside the pod.
 extraContainers: {}
 
+# -- SecurityContext configuration for the Jellyfin pod
+podSecurityContext: {}
+# Jellyfin can be run as an unprivileged user with the following settings:
+  # runAsUser: 65534
+  # runAsGroup: 65534
+
+# -- SecurityContext configuration for the Jellyfin container
+securityContext: {}
+# For example, you might need to grant the following capabilities to enable hardware acceleration when mounting a /dev/dri device:
+  # capabilities:
+  #   add:
+  #     - "SYS_ADMIN"
+  #   drop:
+  #     - "ALL"
+
 # -- Larger libraries may need to increase the readinessProbe and livenessProbe timeouts. Start by increasing the initialDelaySeconds.
 livenessProbe:
   enabled: true


### PR DESCRIPTION
Hi folks,

thanks for putting together this Helm chart!

I like to run the containers in my clusters as unprivileged users, hence I need access to the `pod.spec.securityContext` and `container.securityContext` fields. Maybe someone else will find it useful as well.

While I was at it I also added a paragraph to the README that explains how to get hardware acceleration working.

Cheers!