### PR TITLE
Update chart to have imagePullSecrets option.

### DIFF
--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 10.9.11
 description: Jellyfin Media Server
 name: jellyfin
-version: 1.3.1
+version: 1.3.0
 type: application
 home: https://jellyfin.org/
 icon: https://jellyfin.org/images/logo.svg

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 10.9.11
 description: Jellyfin Media Server
 name: jellyfin
-version: 1.3.0
+version: 1.3.1
 type: application
 home: https://jellyfin.org/
 icon: https://jellyfin.org/images/logo.svg

--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- if .Values.enableDLNA }}
       hostNetwork: true
     {{- end }}

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -1,6 +1,7 @@
 # -- Number of jellyfin replicas to start. Should be left at 1
 replicaCount: 1
 
+imagePullSecrets: []
 image:
   # -- Set cutom repository for jellyfin image
   repository: docker.io/jellyfin/jellyfin


### PR DESCRIPTION
Allow hosted container on a registry with authentication(e.g., a caching proxy registry).
Chart version bumped to 1.30.1.