### PR TITLE
feat: ✨ add metrics and serviceMontior

### DIFF
--- a/charts/jellyfin/templates/_helpers.tpl
+++ b/charts/jellyfin/templates/_helpers.tpl
@@ -1,4 +1,12 @@
 {{/* vim: set filetype=mustache: */}}
+
+{{/*
+Fail if command and metrics are set
+*/}}
+{{- if and .Values.image.command .Values.metrics.enabled }}
+{{- fail "Can't use custom command and metrics in combination. They are exclusive features" }}
+{{- end }}
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -39,9 +39,13 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{ if .Values.image.command }}
+        {{ if and .Values.image.command (not .Values.metrics.enabled) }}
           command:
             {{- toYaml .Values.image.command | nindent 12 }}
+        {{- end }}
+        {{ if .Values.metrics.enabled }}
+          command:
+            {{- toYaml .Values.metrics.command | nindent 12 }}
         {{- end }}
         {{ if .Values.image.args }}
           args:

--- a/charts/jellyfin/templates/service.yaml
+++ b/charts/jellyfin/templates/service.yaml
@@ -40,7 +40,7 @@ spec:
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   ports:
-    - name: http
+    - name: {{ .Values.service.name }}
       port: {{ .Values.service.port }}
       protocol: TCP
       targetPort: http

--- a/charts/jellyfin/templates/serviceMonitor.yaml
+++ b/charts/jellyfin/templates/serviceMonitor.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.metrics.serviceMonitor.enabled .Values.metrics.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "jellyfin.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ tpl .Values.metrics.serviceMonitor.namespace . }}
+  {{- else }}
+  labels:
+    app.kubernetes.io/name: {{ include "jellyfin.name" . }}
+    helm.sh/chart: {{ include "jellyfin.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- tpl (toYaml . | nindent 4) $ }}
+    {{- end }}
+spec:
+  endpoints:
+  - port: {{ .Values.service.name }}
+    {{- with .Values.metrics.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    honorLabels: true
+    path: {{ .Values.metrics.serviceMonitor.path }}
+    scheme: {{ .Values.metrics.serviceMonitor.scheme }}
+    {{- with .Values.metrics.serviceMonitor.tlsConfig }}
+    tlsConfig:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "jellyfin.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.metrics.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -18,6 +18,7 @@ fullnameOverride: ""
 enableDLNA: false
 
 service:
+  name: http
   type: ClusterIP
   port: 8096
   ## Specify the nodePort value for the LoadBalancer and NodePort service types.
@@ -37,6 +38,41 @@ service:
   # loadBalancerSourceRanges: []
   ## Set the externalTrafficPolicy in the Service to either Cluster or Local
   # externalTrafficPolicy: Cluster
+
+# -- Configuration for metrics collection and monitoring
+metrics:
+  # -- Enable or disable metrics collection
+  enabled: false
+  command:
+    - bash
+    - '-c'
+    - >-
+      sed 's,<EnableMetrics>false</EnableMetrics>,<EnableMetrics>true</EnableMetrics>,' -i /config/config/system.xml &&
+      /jellyfin/jellyfin
+  # -- Configuration for the Prometheus ServiceMonitor
+  serviceMonitor:
+    # -- Enable or disable the creation of a ServiceMonitor resource
+    enabled: false
+    # -- Namespace where the ServiceMonitor resource should be created. Defaults to Release.Namespace
+    namespace: ''
+    # -- Labels to add to the ServiceMonitor resource
+    labels: {}
+    # -- Interval at which metrics should be scraped
+    interval: 30s
+    # -- Timeout for scraping metrics
+    scrapeTimeout: 30s
+    # -- Path to scrape for metrics
+    path: /metrics
+    # -- Scheme to use for scraping metrics (http or https)
+    scheme: http
+    # -- TLS configuration for scraping metrics
+    tlsConfig: {}
+    # -- Relabeling rules for the scraped metrics
+    relabelings: []
+    # -- Relabeling rules for the metrics before ingestion
+    metricRelabelings: []
+    # -- Target labels to add to the scraped metrics
+    targetLabels: []
 
 ingress:
   enabled: false


### PR DESCRIPTION
This PR adds the flexibility to fully customize a serviceMonitor resource for jellyfin and also adds the necessary command to activate the metrics. 

Inspiration taken from #28. In the long term a env variable should be introduced inside the docker container to toggle metrics.

@crobibero once my two PRs are merged. I am planning to bring the helm chart to the new standards and template a few more thing and simplify them.