### PR TITLE
fix: YAML parse error when using runtimeClassName

### DIFF
--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -119,5 +119,5 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.runtimeClassName }}
-      runtimeClassName: {{- . | quote }}
+      runtimeClassName: {{ . | quote }}
       {{- end }}


### PR DESCRIPTION
Fixes the error that appeared when using `runtimeClassName`:

> Error: YAML parse error on jellyfin/templates/deployment.yaml: error converting YAML to JSON: yaml: line 64: could not find expected ':'