### PR TITLE
chore: Add metrics warning

### DIFF
--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -187,7 +187,7 @@ persistence:
 
 # -- Configuration for metrics collection and monitoring
 metrics:
-  # -- Enable or disable metrics collection
+  # -- Enable or disable metrics collection - Ensure you have started and configured your Jellyfin instance first as this will fail if system.xml does not exist yet.
   enabled: false
   command:
     - bash


### PR DESCRIPTION
This adds a small warning about enabling metrics before the server has had a chance to configure.

This helps people like me who are too quick to enable metrics and then wondering why the pod is failing to start.