### PR TITLE
chore(renovate): Track upstream jellyfin version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>jellyfin/.github//renovate-presets/default"
+  "extends": ["github>jellyfin/.github//renovate-presets/default"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["charts/jellyfin/Chart.yaml"],
+      "matchStrings": ["appVersion: (?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "jellyfin/jellyfin"
+    }
   ]
 }


### PR DESCRIPTION
jellyfin's at 10.10.1 while upstream's at 10.10.5. adding renovate config to track this automatically since y'all already have renovate set up for actions.

feel free to reject if you prefer manual version management, just tryna reduce my local renovate complexity

btw there's a typo in the automated commit message ("reademe" -> "readme")