### PR TITLE
fix: :bug: unify value name and add default

### DIFF
--- a/charts/jellyfin/templates/service.yaml
+++ b/charts/jellyfin/templates/service.yaml
@@ -47,7 +47,7 @@ spec:
   externalTrafficPolicy: {{ . }}
   {{- end }}
   ports:
-    - name: {{ .Values.service.portName | default "http" }}
+    - name: {{ .Values.service.name | default "http" }}
       port: {{ .Values.service.port }}
       protocol: TCP
       targetPort: http

--- a/charts/jellyfin/templates/serviceMonitor.yaml
+++ b/charts/jellyfin/templates/serviceMonitor.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: {{ .Values.service.name }}
+    - port: {{ .Values.service.name | default "http" }}
       {{- with .Values.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
@@ -23,7 +23,6 @@ spec:
       {{- end }}
       honorLabels: true
       path: {{ .Values.metrics.serviceMonitor.path }}
-      port: {{ .Values.metrics.serviceMonitor.port }}
       scheme: {{ .Values.metrics.serviceMonitor.scheme }}
       {{- with .Values.metrics.serviceMonitor.tlsConfig }}
       tlsConfig:

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -58,6 +58,8 @@ deploymentStrategy:
   type: RollingUpdate
 
 service:
+  # # -- Custom name for the service port
+  # name: http
   # -- Service type (ClusterIP, NodePort, or LoadBalancer).
   type: ClusterIP
   # -- Configure dual-stack IP family policy. See: https://kubernetes.io/docs/concepts/services-networking/dual-stack/


### PR DESCRIPTION
The last rework of the servicemonitor broke the chart. This fixes it and unifies the values for service name