### PR TITLE
Add option for deployment annotations

### DIFF
--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "jellyfin.fullname" . }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "jellyfin.labels" . | nindent 4 }}
 spec:

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -57,6 +57,9 @@ runtimeClassName: ''
 deploymentStrategy:
   type: RollingUpdate
 
+# -- Annotations to add to the deployment.
+deploymentAnnotations: {}
+
 service:
   # # -- Custom name for the service port
   # name: http


### PR DESCRIPTION
When using [Stakater Reloader](https://github.com/stakater/Reloader), it is required to add Deployment annotations to restart the deployment when a mounted configmap/secret is changed. This is useful when using the Jellyfin HTTPS option with a certificate secret mounted from cert-manager