### PR TITLE
A few small changes for some QoL

### DIFF
--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     {{- toYaml . | trim | nindent 4 }}
   {{- end }}
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "jellyfin.selectorLabels" . | nindent 6 }}
@@ -61,6 +62,10 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.jellyfin.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8096
@@ -82,13 +87,15 @@ spec:
               name: config
             - mountPath: /media
               name: media
+            - mountPath: /cache
+              name: cache
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.initContainers }}
+      {{- with .Values.extraInitContainers }}
       initContainers:
         {{- toYaml . | nindent 6 }}
       {{- end }}
@@ -104,6 +111,13 @@ spec:
           {{- if .Values.persistence.media.enabled }}
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.media.existingClaim }}{{ .Values.persistence.media.existingClaim }}{{- else }}{{ template "jellyfin.fullname" . }}-media{{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: cache
+          {{- if .Values.persistence.cache.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.cache.existingClaim }}{{ .Values.persistence.cache.existingClaim }}{{- else }}{{ template "jellyfin.fullname" . }}-cache{{- end }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/charts/jellyfin/templates/persistentVolumeClaim.yaml
+++ b/charts/jellyfin/templates/persistentVolumeClaim.yaml
@@ -1,45 +1,23 @@
-{{- if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
+{{- range $volume := list "media" "config" "cache" }}
+{{- with $value := index $.Values.persistence $volume }}
+{{- if eq $value.enabled true }}
 ---
-apiVersion: v1
 kind: PersistentVolumeClaim
+apiVersion: v1
 metadata:
-  name: {{ include "jellyfin.fullname" . }}-config
+  name: {{ include "jellyfin.fullname" $ }}-{{ $volume }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "jellyfin.labels" . | nindent 4 }}
-  {{- with .Values.persistence.config.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- include "jellyfin.labels" $ | nindent 4 }}
 spec:
   accessModes:
-    - {{ .Values.persistence.config.accessMode | quote }}
+    - {{ $value.accessMode | quote }}
   resources:
     requests:
-      storage: {{ .Values.persistence.config.size | quote }}
-  {{- with .Values.persistence.config.storageClass }}
-  storageClassName: {{ . | quote }}
+      storage: {{ $value.size | quote }}
+  {{- with $value.storageClass }}
+  storageClassName: {{ . }}
   {{- end }}
 {{- end }}
-
-{{- if and .Values.persistence.media.enabled (not .Values.persistence.media.existingClaim) }}
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ include "jellyfin.fullname" . }}-media
-  labels:
-    {{- include "jellyfin.labels" . | nindent 4 }}
-  {{- with .Values.persistence.media.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  accessModes:
-    - {{ .Values.persistence.media.accessMode | quote }}
-  resources:
-    requests:
-      storage: {{ .Values.persistence.media.size | quote }}
-  {{- with .Values.persistence.media.storageClass }}
-  storageClassName: {{ . | quote }}
-  {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -4,6 +4,10 @@
 # -- Number of Jellyfin replicas to start. Should be left at 1.
 replicaCount: 1
 
+# -- Specify how many old ReplicaSets for this Deployment you want to retain.
+# See: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy
+revisionHistoryLimit: 10
+
 # -- Image pull secrets to authenticate with private repositories.
 # See: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -168,6 +172,8 @@ jellyfin:
   args: []
   # -- Additional environment variables for the container.
   env: []
+  # -- Additional environment variables for the container from ConfigMap's or Secrets.
+  envFrom: []
 
 persistence:
   config:
@@ -186,6 +192,17 @@ persistence:
     enabled: true
     accessMode: ReadWriteOnce
     size: 25Gi
+    # -- Custom annotations to be added to the PVC
+    annotations: {}
+    # -- If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.
+    storageClass: ''
+    ## -- Use an existing PVC for this mount
+    # existingClaim: ''
+  cache:
+    # -- set to false to use emptyDir
+    enabled: false
+    accessMode: ReadWriteOnce
+    size: 5Gi
     # -- Custom annotations to be added to the PVC
     annotations: {}
     # -- If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.


### PR DESCRIPTION
Greetings friends

I've forked and made a few changes to the chart for myself and thought I'd send a PR for review.

1. Make revisionHistoryLimit configurable with a default of 10. For those like myself using tools like ArgoCD to manage deployments, this cuts down noise as revision history in Argo is redundant when the history is in Git. 
2. Add envFrom to allow importing environment variables from a ConfigMap or Secrets. Not particularly useful with the chart on it's own, but for more advanced users making umbrella charts importing from a ConfigMap could shrink the values file, but with support for external databases in the works will hopefully have value _soon_
3. The initContainers didn't match between the values.yaml file and deployment.yaml. Made them match. 
4. Added a cache volume and refactored persistentVolumeClaim.yaml to use a range in order to cut down repetition