### PR TITLE
feat: allow to enable some pod privileges (hostIPC...)

### DIFF
--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -36,8 +36,14 @@ spec:
       serviceAccountName: {{ include "jellyfin.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.jellyfin.enableDLNA }}
+      {{- if or .Values.jellyfin.enableDLNA .Values.podPrivileges.hostNetwork }}
       hostNetwork: true
+      {{- end }}
+      {{- if .Values.podPrivileges.hostIPC }}
+      hostIPC: true
+      {{- end }}
+      {{- if .Values.podPrivileges.hostPID }}
+      hostPID: true
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -175,6 +175,15 @@ tolerations: []
 # -- Affinity rules for pod scheduling.
 affinity: {}
 
+# -- Privileged pod settings for advanced use cases
+podPrivileges:
+  # -- Enable hostIPC namespace. Required for NVIDIA MPS (Multi-Process Service) GPU sharing. See: https://docs.nvidia.com/deploy/mps/index.html
+  hostIPC: false
+  # -- Enable hostNetwork. Allows pod to use the host's network namespace.
+  hostNetwork: false
+  # -- Enable hostPID namespace. Allows pod to see processes on the host.
+  hostPID: false
+
 jellyfin:
   # -- Enable DLNA. Requires host network. See: https://jellyfin.org/docs/general/networking/dlna.html
   enableDLNA: false


### PR DESCRIPTION
Those flags are useful for advanced use cases, such using the nvidia MPS