### PR TITLE
ci(release): Format release notes with changelog and emojis

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,9 +32,128 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Install yq
+        run: |
+          # renovate: datasource=github-releases depName=mikefarah/yq
+          YQ_VERSION="4.44.3"
+          wget -q https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 -O yq
+          chmod +x yq
+          sudo mv yq /usr/local/bin/yq
+          yq --version
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           config: .github/cr.yaml
+
+      - name: Extract chart metadata and format release notes
+        id: release-notes
+        run: |
+          CHART_PATH="charts/jellyfin"
+          CHART_NAME=$(yq eval '.name' "${CHART_PATH}/Chart.yaml")
+          CHART_VERSION=$(yq eval '.version' "${CHART_PATH}/Chart.yaml")
+          APP_VERSION=$(yq eval '.appVersion' "${CHART_PATH}/Chart.yaml")
+          RELEASE_TAG="${CHART_NAME}-${CHART_VERSION}"
+
+          echo "tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
+
+          CHANGELOG_RAW=$(yq eval '.annotations."artifacthub.io/changes"' "${CHART_PATH}/Chart.yaml")
+
+          # Build changelog section
+          CHANGELOG_SECTION=""
+          if [ "$CHANGELOG_RAW" != "null" ] && [ -n "$CHANGELOG_RAW" ]; then
+            CHANGELOG_SECTION="## What's Changed
+
+          "
+            TEMP_FILE=$(mktemp)
+            SEPARATOR="|"
+            echo "$CHANGELOG_RAW" | yq eval ".[] | .kind + \"${SEPARATOR}\" + .description" - > "$TEMP_FILE"
+
+            while IFS="${SEPARATOR}" read -r kind description; do
+              case "$kind" in
+                "added")
+                  emoji="✨"
+                  label="Added"
+                  ;;
+                "changed")
+                  emoji="🔄"
+                  label="Changed"
+                  ;;
+                "deprecated")
+                  emoji="⚠️"
+                  label="Deprecated"
+                  ;;
+                "removed")
+                  emoji="🗑️"
+                  label="Removed"
+                  ;;
+                "fixed")
+                  emoji="🐛"
+                  label="Fixed"
+                  ;;
+                "security")
+                  emoji="🔒"
+                  label="Security"
+                  ;;
+                *)
+                  emoji="📝"
+                  label="Changed"
+                  ;;
+              esac
+              CHANGELOG_SECTION="${CHANGELOG_SECTION}- ${emoji} **${label}**: ${description}
+          "
+            done < "$TEMP_FILE"
+
+            rm -f "$TEMP_FILE"
+            CHANGELOG_SECTION="${CHANGELOG_SECTION}
+          "
+          fi
+
+          # Build release body
+          RELEASE_BODY="## Jellyfin Helm Chart v${CHART_VERSION}
+
+          **Application Version**: \`${APP_VERSION}\`
+
+          ${CHANGELOG_SECTION}## Installation
+
+          Add the Jellyfin Helm repository:
+
+          \`\`\`bash
+          helm repo add jellyfin https://jellyfin.github.io/jellyfin-helm
+          helm repo update
+          \`\`\`
+
+          Install the chart:
+
+          \`\`\`bash
+          helm install my-jellyfin jellyfin/jellyfin --version ${CHART_VERSION}
+          \`\`\`
+
+          ## Upgrade
+
+          \`\`\`bash
+          helm upgrade my-jellyfin jellyfin/jellyfin --version ${CHART_VERSION}
+          \`\`\`
+
+          ---
+
+          📦 **Chart**: \`jellyfin\` v${CHART_VERSION}
+          🎬 **Jellyfin**: v${APP_VERSION}
+          📖 **Documentation**: https://github.com/jellyfin/jellyfin-helm/blob/main/charts/jellyfin/README.md
+          "
+
+          # Save to file
+          echo "$RELEASE_BODY" > release-notes.md
+
+      - name: Update release notes
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          RELEASE_TAG="${{ steps.release-notes.outputs.tag }}"
+
+          # Update release notes
+          gh release edit "$RELEASE_TAG" --notes-file release-notes.md
+
+          echo "✅ Updated release notes for $RELEASE_TAG"


### PR DESCRIPTION
## Summary

Automatically extract and format changelog from `artifacthub.io/changes` annotations and update GitHub release notes with comprehensive information.

## Problem

Current releases only contain "A Helm chart for Jellyfin Media Server" without any information about what changed between versions. This makes it difficult for users to understand what's new or fixed.

### Before
```
A Helm chart for Jellyfin Media Server
```

### After
```markdown
## Jellyfin Helm Chart v2.5.0

**Application Version**: `10.11.0`

## What's Changed

- ✨ **Added**: New feature X
- 🐛 **Fixed**: Bug in Y
- 🔄 **Changed**: Updated Z

## Installation

Add the Jellyfin Helm repository:

`helm repo add jellyfin https://jellyfin.github.io/jellyfin-helm`
`helm repo update`

Install the chart:

`helm install my-jellyfin jellyfin/jellyfin --version 2.5.0`

## Upgrade

`helm upgrade my-jellyfin jellyfin/jellyfin --version 2.5.0`

---

📦 **Chart**: `jellyfin` v2.5.0
🎬 **Jellyfin**: v10.11.0
📖 **Documentation**: https://github.com/jellyfin/jellyfin-helm/blob/main/charts/jellyfin/README.md
```

## Changes

1. **Install yq**: Required for parsing YAML and extracting annotations
2. **Extract changelog**: Parse `artifacthub.io/changes` from Chart.yaml
3. **Format with emojis**: Add appropriate emoji based on change kind:
   - ✨ Added
   - 🐛 Fixed
   - 🔄 Changed
   - 🗑️ Removed
   - ⚠️ Deprecated
   - 🔒 Security
4. **Build comprehensive notes**: Include versions, changelog, installation/upgrade instructions, and documentation links
5. **Update release**: Use `gh release edit` to update notes after chart-releaser creates the release

## Benefits

- **Better user experience**: Users can see what changed without checking commit history
- **Professional appearance**: Formatted changelog with emojis looks modern and organized
- **Complete information**: Installation instructions and links in every release
- **Leverages existing data**: Uses artifacthub.io/changes that maintainers already provide

## Testing

The workflow runs after chart-releaser-action completes, ensuring backward compatibility. If no changelog exists, the script handles it gracefully.

## Notes

This change works with the existing chart-releaser workflow and doesn't break anything. The workflow:
1. Runs chart-releaser as usual (creates release with default description)
2. Extracts and formats changelog
3. Updates release notes with formatted content