### PR TITLE
Set version label based on tag if set

### DIFF
--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -8,5 +8,5 @@ keywords:
   - jellyfin
   - media
   - self-hosted
-version: 2.7.0
+version: 2.7.1
 appVersion: 10.11.5

--- a/charts/jellyfin/templates/_helpers.tpl
+++ b/charts/jellyfin/templates/_helpers.tpl
@@ -43,7 +43,9 @@ Common labels
 {{- define "jellyfin.labels" -}}
 helm.sh/chart: {{ include "jellyfin.chart" . }}
 {{ include "jellyfin.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
+{{- if .Values.image.tag }}
+app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+{{- else if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}


### PR DESCRIPTION
The `app.kubernetes.io/version` label is supposed to show the current version of the software installed, but when the user overrides the Jellyfin version using `image.tag` then the label becomes wrong since it still uses `AppVersion`. By prioritising the `tag` over `AppVersion` for this label, this is fixed.

Also update version of Helm chart. This is a bugfix since it makes sure to show the correct version that should've been displayed anyway.