### PR TITLE
fix: NOTES.txt templating errors with gateway API and redundant conditional

### DIFF
--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -8,10 +8,12 @@ keywords:
   - jellyfin
   - media
   - self-hosted
-version: 3.0.0
+version: 3.0.1
 appVersion: 10.11.7
 annotations:
   artifacthub.io/changes: |
+    - kind: fixes
+      description: Fix NOTES.txt templating for Gateway API host/path rendering and remove redundant conditional
     - kind: deprecated
       description: Deprecate initContainers parameter in favor of extraInitContainers for consistency (will be removed after 2030)
     - kind: fixed

--- a/charts/jellyfin/templates/NOTES.txt
+++ b/charts/jellyfin/templates/NOTES.txt
@@ -123,8 +123,24 @@ HTTPRoute (Gateway API) is ENABLED:
 
 Access Jellyfin via Gateway API at:
 {{- if .Values.httpRoute.hostnames }}
-{{- range .Values.httpRoute.hostnames }}
-  https://{{ . }}{{ (index $.Values.httpRoute.rules 0).matches 0 .path.value }}
+{{- range $host := .Values.httpRoute.hostnames }}
+  {{- if $.Values.httpRoute.rules }}
+    {{- range $rule := $.Values.httpRoute.rules }}
+      {{- if $rule.matches }}
+        {{- range $match := $rule.matches }}
+          {{- $path := "/" -}}
+          {{- if and $match.path $match.path.value -}}
+            {{- $path = $match.path.value -}}
+          {{- end}}
+  https://{{ $host }}{{ $path }}
+        {{- end }}
+      {{- else }}
+  https://{{ $host }}/
+      {{- end }}
+    {{- end }}
+  {{- else }}
+  https://{{ $host }}/
+  {{- end }}
 {{- end }}
 {{- else }}
   (Configure httpRoute.hostnames for external access)
@@ -132,6 +148,7 @@ Access Jellyfin via Gateway API at:
 
 Note: Ensure your Gateway API CRDs are installed and Gateway is configured.
 {{- else if .Values.ingress.enabled }}
+
 Jellyfin is available via Ingress at:
 {{- range .Values.ingress.hosts }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ (index .paths 0).path }}


### PR DESCRIPTION
Similar to PR #110 , when using the Gateway API and http routes, helm will complain if `httpRoute` is enabled due to a bad template in NOTES.txt under the Gateway API section.

As the other PR hasn't been merged yet, this PR also contains their fix. Happy to remove it from this PR once their one is merged.