### PR TITLE
docs(hardware acceleration): use volumes and volumeMounts instead of extraVolumes and extraVolumeMounts for the hwa example, as the chart does not use the extra prefix

### DIFF
--- a/charts/jellyfin/README.md
+++ b/charts/jellyfin/README.md
@@ -214,12 +214,12 @@ securityContext:
       - "ALL"
   privileged: false
 
-extraVolumes:
+volumes:
   - name: hwa
     hostPath:
       path: /dev/dri
 
-extraVolumeMounts:
+volumeMounts:
   - name: hwa
     mountPath: /dev/dri
 ```

--- a/charts/jellyfin/README.md.gotmpl
+++ b/charts/jellyfin/README.md.gotmpl
@@ -103,12 +103,12 @@ securityContext:
       - "ALL"
   privileged: false
 
-extraVolumes:
+volumes:
   - name: hwa
     hostPath:
       path: /dev/dri
 
-extraVolumeMounts:
+volumeMounts:
   - name: hwa
     mountPath: /dev/dri
 ```


### PR DESCRIPTION
The example for the hwa used `extraVolumes` and `extranVolumeMounts`, which are not used by the chart itself. Instead the chart uses [`volumes`](https://github.com/jellyfin/jellyfin-helm/blob/73f72c237d227b4bdecb61ddc5bd60898efd2ca5/charts/jellyfin/values.yaml#L209) and [`volumeMounts`](https://github.com/jellyfin/jellyfin-helm/blob/73f72c237d227b4bdecb61ddc5bd60898efd2ca5/charts/jellyfin/values.yaml#L216).

The same applies to the docs on jellyfin.org (https://jellyfin.org/docs/general/installation/advanced/kubernetes#hardware-acceleration). I a willing to submit a fix for this also, as soon as this is accepted. 