### PR TITLE
Update docs_update.yaml - switch to using main branch for doc updates

### DIFF
--- a/.github/workflows/docs_update.yaml
+++ b/.github/workflows/docs_update.yaml
@@ -3,7 +3,7 @@ name: Docs Update
 on:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
This is to help with the goal of accomplishing #129 by making sure the doc CI job runs on the `main` branch.