### PR TITLE
Enable adding labels to PVCs

### DIFF
--- a/charts/jellyfin/templates/persistentVolumeClaim.yaml
+++ b/charts/jellyfin/templates/persistentVolumeClaim.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "jellyfin.fullname" . }}-config
   labels:
     {{- include "jellyfin.labels" . | nindent 4 }}
+    {{- with .Values.persistence.config.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.persistence.config.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -29,6 +32,9 @@ metadata:
   name: {{ include "jellyfin.fullname" . }}-media
   labels:
     {{- include "jellyfin.labels" . | nindent 4 }}
+    {{- with .Values.persistence.media.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.persistence.media.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -52,6 +58,9 @@ metadata:
   name: {{ include "jellyfin.fullname" . }}-cache
   labels:
     {{- include "jellyfin.labels" . | nindent 4 }}
+    {{- with .Values.persistence.cache.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.persistence.cache.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/jellyfin/tests/cache_persistence_test.yaml
+++ b/charts/jellyfin/tests/cache_persistence_test.yaml
@@ -122,6 +122,19 @@ tests:
           path: spec.storageClassName
           value: fast-ssd
 
+  - it: should add labels to cache PVC
+    template: persistentVolumeClaim.yaml
+    documentIndex: 2
+    set:
+      persistence.cache.enabled: true
+      persistence.cache.type: pvc
+      persistence.cache.labels:
+        my-label: my-value
+    asserts:
+      - equal:
+          path: metadata.labels.my-label
+          value: my-value
+
   - it: should add annotations to cache PVC
     template: persistentVolumeClaim.yaml
     documentIndex: 2

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -268,6 +268,8 @@ persistence:
     enabled: true
     accessMode: ReadWriteOnce
     size: 5Gi
+    # -- Custom labels to be added to the PVC
+    labels: {}
     # -- Custom annotations to be added to the PVC
     annotations: {}
     # -- If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.
@@ -284,6 +286,8 @@ persistence:
     # -- PVC specific settings, only used if type is 'pvc'.
     accessMode: ReadWriteOnce
     size: 25Gi
+    # -- Custom labels to be added to the PVC
+    labels: {}
     # -- Custom annotations to be added to the PVC
     annotations: {}
     # -- If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.
@@ -300,6 +304,8 @@ persistence:
     # -- PVC specific settings, only used if type is 'pvc'.
     accessMode: ReadWriteOnce
     size: 10Gi
+    # -- Custom labels to be added to the PVC
+    labels: {}
     # -- Custom annotations to be added to the PVC
     annotations: {}
     # -- If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.


### PR DESCRIPTION
Adds parameters:

- `persistence.config.labels`
- `persistence.media.labels`
- `persistence.cache.labels`

These just set labels on PVCs, same as `persistence.*.annotations`.

I also added a test case for `persistence.cache.labels` since I saw there was already one for `persistence.config.annotations`.