### PR TITLE
feat: add support for custom service reference in ingress

### DIFF
--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -8,10 +8,12 @@ keywords:
   - jellyfin
   - media
   - self-hosted
-version: 3.2.0
+version: 3.3.0
 appVersion: 10.11.11
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: Add options for customizing the ingress service
     - kind: fixes
       description: Fix NOTES.txt templating for Gateway API host/path rendering and remove redundant conditional
     - kind: deprecated

--- a/charts/jellyfin/README.md
+++ b/charts/jellyfin/README.md
@@ -1,6 +1,6 @@
 # jellyfin
 
-![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.11.11](https://img.shields.io/badge/AppVersion-10.11.11-informational?style=flat-square)
+![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.11.11](https://img.shields.io/badge/AppVersion-10.11.11-informational?style=flat-square)
 
 A Helm chart for Jellyfin Media Server
 
@@ -68,7 +68,8 @@ helm install my-jellyfin jellyfin/jellyfin -f values.yaml
 | image.repository | string | `"docker.io/jellyfin/jellyfin"` | Container image repository for Jellyfin. |
 | image.tag | string | `""` | Jellyfin container image tag. Leave empty to automatically use the Chart's app version. |
 | imagePullSecrets | list | `[]` | Image pull secrets to authenticate with private repositories. See: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
-| ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}],"tls":[]}` | Ingress configuration. See: https://kubernetes.io/docs/concepts/services-networking/ingress/ |
+| ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}],"service":{},"tls":[]}` | Ingress configuration. See: https://kubernetes.io/docs/concepts/services-networking/ingress/ |
+| ingress.service | object | `{}` | Optional: custom backend service (defaults to the chart's service name and port) |
 | initContainers | list | `[]` | DEPRECATED: Use extraInitContainers instead. Will be removed after 2030. @deprecated - This parameter is deprecated, use extraInitContainers instead |
 | jellyfin.args | list | `[]` | Additional arguments for the entrypoint command. |
 | jellyfin.command | list | `[]` | Custom command to use as container entrypoint. |

--- a/charts/jellyfin/templates/ingress.yaml
+++ b/charts/jellyfin/templates/ingress.yaml
@@ -35,9 +35,9 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ include "jellyfin.fullname" $ }}
+                name: {{ $.Values.ingress.service.name | default (include "jellyfin.fullname" $) }}
                 port:
-                  number: {{ $.Values.service.port }}
+                  number: {{ $.Values.ingress.service.port | default $.Values.service.port }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -127,6 +127,10 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  # -- Optional: custom backend service (defaults to the chart's service name and port)
+  service: {}
+  #   name: my-other-service
+  #   port: 8096
   hosts:
     - host: chart-example.local
       paths:


### PR DESCRIPTION
Hey!

I am using KEDA (https://keda.sh) in my private cluster and would like to scale Jellyfin automatically once the Ingress URL is accessed (e.g.: via the Jellyfin iOS app).

To be able to do that, the Jellyfin Ingress needs to point to the keda interceptor service like:

```yaml
      - backend:
          service:
            name: keda-interceptor
            port:
              number: 8080
```

Currently this is not possible with this chart but my changes will allow users to change the backend, while keeping the current behavior as default.

> Note: this re-opens #117, which was accidentally closed when my previous fork was deleted.