### PR TITLE
feat: allow configuring httpRoute filters

### DIFF
--- a/charts/jellyfin/templates/httproute.yaml
+++ b/charts/jellyfin/templates/httproute.yaml
@@ -29,5 +29,9 @@ spec:
       backendRefs:
         - name: {{ include "jellyfin.fullname" $ }}
           port: {{ $.Values.service.port }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -157,6 +157,14 @@ httpRoute:
         - path:
             type: PathPrefix
             value: /
+      # -- Configure optional filters (https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httproutefilter)
+      # -- Sample filter
+      #filters:
+      #  - type: RequestHeaderModifier
+      #    requestHeaderModifier:
+      #      add:
+      #        - name: my-header
+      #          value: foo
 
 # -- Resource requests and limits for the Jellyfin container.
 resources: {}


### PR DESCRIPTION
Extend httpRoute logic to allow configuration of filters, which could also be used to secure the /metrics endpoint with basic auth or oauth2 to not directly expose it to the internet.

Sample values.yaml to achieve this with Traefik Middleware:

```YAML
httpRoute:
  enabled: true
  rules:
   # base path to jellyfin
    - matches:
        - path:
            type: PathPrefix
            value: /
    # secure metrics endpoint with oauth2-proxy through traefik middleware
    - matches:
        - path:
            type: PathPrefix
            value: /metrics
      filters:
        - type: ExtensionRef
          extensionRef:
            group: traefik.io
            kind: Middleware
            name: oauth-forwardauth
        - type: ExtensionRef
          extensionRef:
            group: traefik.io
            kind: Middleware
            name: oauth-forwardauth-service
```