### PR TITLE
fix: Add missing namespace fields

### DIFF
--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - jellyfin
   - media
   - self-hosted
-version: 3.2.0
+version: 3.2.1
 appVersion: 10.11.11
 annotations:
   artifacthub.io/changes: |

--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "jellyfin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.deploymentAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/jellyfin/templates/httproute.yaml
+++ b/charts/jellyfin/templates/httproute.yaml
@@ -3,6 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "jellyfin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jellyfin.labels" . | nindent 4 }}
   {{- with .Values.httpRoute.annotations }}

--- a/charts/jellyfin/templates/ingress.yaml
+++ b/charts/jellyfin/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "jellyfin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jellyfin.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/jellyfin/templates/networkpolicy.yaml
+++ b/charts/jellyfin/templates/networkpolicy.yaml
@@ -7,6 +7,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "jellyfin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jellyfin.labels" . | nindent 4 }}
 spec:

--- a/charts/jellyfin/templates/persistentVolumeClaim.yaml
+++ b/charts/jellyfin/templates/persistentVolumeClaim.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "jellyfin.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jellyfin.labels" . | nindent 4 }}
     {{- with .Values.persistence.config.labels }}
@@ -30,6 +31,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "jellyfin.fullname" . }}-media
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jellyfin.labels" . | nindent 4 }}
     {{- with .Values.persistence.media.labels }}
@@ -56,6 +58,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "jellyfin.fullname" . }}-cache
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jellyfin.labels" . | nindent 4 }}
     {{- with .Values.persistence.cache.labels }}

--- a/charts/jellyfin/templates/service.yaml
+++ b/charts/jellyfin/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "jellyfin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jellyfin.labels" . | nindent 4 }}
     {{- with .Values.service.labels }}

--- a/charts/jellyfin/templates/serviceMonitor.yaml
+++ b/charts/jellyfin/templates/serviceMonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "jellyfin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ tpl .Values.metrics.serviceMonitor.namespace . }}
   {{- end }}

--- a/charts/jellyfin/templates/serviceaccount.yaml
+++ b/charts/jellyfin/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "jellyfin.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jellyfin.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
`helm template` fails to use `--namespace` like `helm install` does. This fixes that as per: https://github.com/kubernetes-sigs/kustomize/issues/6058

This will fix install errors when deploying to K8s with a `kustomization.yml` file that looks like this:
```yaml
namespace: jellyfin

resources:
  - resources/namespace.yml
  - resources/persistentVolume.yml
  - resources/persistentVolumeClaim.yml

helmCharts:
  - includeCRDs: true
    name: jellyfin
    namespace: jellyfin
    releaseName: jellyfin
    repo: https://jellyfin.github.io/jellyfin-helm
    valuesFile: values.yml
    version: 3.2.0
```

That currently result in:

<img width="2056" height="624" alt="Screenshot 2026-06-25 at 4 21 25 PM" src="https://github.com/user-attachments/assets/7ecd0004-8f6a-40f2-a334-c7c7299bf8d3" />
