### PR TITLE
feat: Added option to use digest instead of version tag

### DIFF
--- a/charts/jellyfin/README.md
+++ b/charts/jellyfin/README.md
@@ -65,8 +65,9 @@ helm install my-jellyfin jellyfin/jellyfin -f values.yaml
 | httpRoute.parentRefs | list | `[]` | Gateway references to attach this HTTPRoute to |
 | httpRoute.rules | list | `[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Rules for routing traffic |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy (Always, IfNotPresent, or Never). |
-| image.repository | string | `"docker.io/jellyfin/jellyfin"` | Container image repository for Jellyfin. |
-| image.tag | string | `""` | Jellyfin container image tag. Leave empty to automatically use the Chart's app version. |
+| image.registry | string | `"docker.io"` | Container image registry for Jellyfin. |
+| image.repository | string | `"jellyfin/jellyfin"` | Container image repository for Jellyfin. |
+| image.version | string | `""` | Jellyfin container image version, can be version tag or digest. Leave empty to automatically use the Chart's app version. |
 | imagePullSecrets | list | `[]` | Image pull secrets to authenticate with private repositories. See: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}],"tls":[]}` | Ingress configuration. See: https://kubernetes.io/docs/concepts/services-networking/ingress/ |
 | initContainers | list | `[]` | DEPRECATED: Use extraInitContainers instead. Will be removed after 2030. @deprecated - This parameter is deprecated, use extraInitContainers instead |

--- a/charts/jellyfin/templates/_helpers.tpl
+++ b/charts/jellyfin/templates/_helpers.tpl
@@ -38,6 +38,22 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Create the image path for the .Values.image field
+Source: https://blog.andyserver.com/2021/09/adding-image-digest-references-to-your-helm-charts/
+*/}}
+{{- define "jellyfin.image" -}}
+{{- if and .Values.image.registry .Values.image.repository ( or .Values.image.version .Chart.AppVersion ) -}}
+    {{- if eq (substr 0 7 .Values.image.version) "sha256:" -}}
+    {{- printf "%s/%s@%s" .Values.image.registry .Values.image.repository .Values.image.version -}}
+    {{- else -}}
+    {{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository ( .Values.image.version | default .Chart.AppVersion ) -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s:%s" .Values.image.repository ( .Values.image.tag | default .Chart.AppVersion ) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "jellyfin.labels" -}}

--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ template "jellyfin.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.jellyfin.command }}
           command:

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -15,10 +15,12 @@ revisionHistoryLimit: 3
 imagePullSecrets: []
 
 image:
+  # -- Container image registry for Jellyfin.
+  registry: docker.io
   # -- Container image repository for Jellyfin.
-  repository: docker.io/jellyfin/jellyfin
-  # -- Jellyfin container image tag. Leave empty to automatically use the Chart's app version.
-  tag: ""
+  repository: jellyfin/jellyfin
+  # -- Jellyfin container image version. Leave empty to automatically use the Chart's app version.
+  version: ""
   # -- Image pull policy (Always, IfNotPresent, or Never).
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Currently it's not possible to use the image digest instead of a version tag.

To be able to do that, I added a helper function from https://blog.andyserver.com/2021/09/adding-image-digest-references-to-your-helm-charts/ that can dynamically change between digest and tag.

This change should be retrocompatible