### PR TITLE
Add missing `readOnly` mount setting to `values.yaml`

### DIFF
--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -292,6 +292,8 @@ persistence:
     storageClass: ''
     ## -- Use an existing PVC for this mount
     # existingClaim: ''
+    # -- Mount media storage as read-only
+    readOnly: false
   cache:
     # -- set to false to use emptyDir
     enabled: false


### PR DESCRIPTION
The deployment already has the `readOnly` setting passed through. It is just missing in the `values.yaml` (for documentation purposes).