### PR TITLE
Add NFS option for media volumes

### DIFF
--- a/charts/jellyfin/templates/NOTES.txt
+++ b/charts/jellyfin/templates/NOTES.txt
@@ -78,7 +78,7 @@ WARNING: Configuration persistence is disabled!
 
 {{- if .Values.persistence.media.enabled }}
 
-Media is {{ if eq .Values.persistence.media.type "hostPath" }}mounted from host path{{ else if eq .Values.persistence.media.type "pvc" }}persisted to PVC{{ else }}stored in emptyDir{{ end }}:
+Media is {{ if eq .Values.persistence.media.type "hostPath" }}mounted from host path{{ else if eq .Values.persistence.media.type "pvc" }}persisted to PVC{{ else if eq .Values.persistence.media.type "nfs" }}mounted from NFS{{ else }}stored in emptyDir{{ end }}:
 {{- if eq .Values.persistence.media.type "hostPath" }}
   Host path: {{ .Values.persistence.media.hostPath }}
 {{- else if eq .Values.persistence.media.type "pvc" }}
@@ -87,6 +87,10 @@ Media is {{ if eq .Values.persistence.media.type "hostPath" }}mounted from host 
   {{- else }}
   PVC: {{ include "jellyfin.fullname" . }}-media
   {{- end }}
+{{- else if eq .Values.persistence.media.type "nfs" }}
+  NFS Server: {{ .Values.persistence.media.nfsServer }}
+  NFS Path: {{ .Values.persistence.media.nfsPath }}
+  Read Only: {{ .Values.persistence.media.readOnly }}
 {{- end }}
 {{- else }}
 

--- a/charts/jellyfin/templates/deployment.yaml
+++ b/charts/jellyfin/templates/deployment.yaml
@@ -167,6 +167,11 @@ spec:
           hostPath:
             path: {{ .Values.persistence.media.hostPath }}
             type: Directory
+            {{- else if eq .Values.persistence.media.type "nfs" }}
+          nfs:
+            server: {{ .Values.persistence.media.nfsServer }}
+            path: {{ .Values.persistence.media.nfsPath }}
+            readOnly: {{ .Values.persistence.media.readOnly }}
             {{- else }}
           emptyDir: {}
             {{- end }}

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -277,7 +277,7 @@ persistence:
   media:
     # -- set to false to use emptyDir
     enabled: true
-    # -- Type of volume for media storage (pvc, hostPath, emptyDir). If 'enabled' is false, 'emptyDir' is used regardless of this setting.
+    # -- Type of volume for media storage (pvc, hostPath, nfs, emptyDir). If 'enabled' is false, 'emptyDir' is used regardless of this setting.
     type: pvc
     # -- Path on the host node for media storage, only used if type is 'hostPath'.
     hostPath: ""
@@ -292,6 +292,10 @@ persistence:
     storageClass: ''
     ## -- Use an existing PVC for this mount
     # existingClaim: ''
+    # -- NFS specific settings, only used if type is 'nfs'.
+    nfsServer: ""
+    nfsPath: ""
+    readOnly: true
   cache:
     # -- set to false to use emptyDir
     enabled: false


### PR DESCRIPTION
This feature allows an NFS volume to be mounted for media directly in the pod without requiring the step of setting it up as a PVC. This can simplify deployments and should be useful for a lot of people who simply need to expose their NAS shares without requiring the features of a PVC (mount options, etc.).

https://github.com/jellyfin/jellyfin-meta/discussions/143