### PR TITLE
Fix default metrics NetworkPolicy podSelector

### DIFF
--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -523,4 +523,5 @@ networkPolicy:
     # Default selector works with prometheus-operator and kube-prometheus-stack.
     # Adjust if your Prometheus uses different labels.
     podSelector:
-      app.kubernetes.io/name: prometheus
+      matchLabels:
+        app.kubernetes.io/name: prometheus


### PR DESCRIPTION
Currently, the `matchLabels` part of the default metrics `podSelector` was missing, causing the selector to revert to `{}` when admitted into the cluster, allowing traffic from any pod in the relevant namespace.

This adds the required `matchLabels` to the selector.